### PR TITLE
Update bokeh

### DIFF
--- a/pvfree/settings/__init__.py
+++ b/pvfree/settings/__init__.py
@@ -58,7 +58,6 @@ ROOT_URLCONF = 'pvfree.urls'
 
 WSGI_APPLICATION = 'pvfree.wsgi.application'
 
-
 # Databases
 # use ElephantSQL database instead of heroku
 DATABASES = {

--- a/pvfree/views.py
+++ b/pvfree/views.py
@@ -43,9 +43,9 @@ def pvinverter_detail(request, pvinverter_id):
         x_axis_label=f'DC power, Pdc [{disp_units}]',
         y_axis_label='efficiency [%]',
         title=pvinv.Name,
-        plot_width=800, plot_height=600, sizing_mode='scale_width')
+        width=800, height=600, sizing_mode='scale_width')
     r = fig.multi_line(
-        dc_power_disp.tolist(), eff_disp.tolist(), color=cmap, line_width=4)
+        dc_power_disp.tolist(), eff_disp.tolist(), color=cmap[:3], line_width=4)
     legend = Legend(items=[
         LegendItem(label='{:d} [V]'.format(int(vdc)), renderers=[r], index=n)
         for n, vdc in enumerate(dc_voltages)])
@@ -92,7 +92,7 @@ def pvmodule_detail(request, pvmodule_id):
         x_axis_label='effective irradiance, Ee [W/m' + u"\u00B2" + ']',
         y_axis_label='efficiency [%]',
         title=pvmod.Name,
-        plot_width=800, plot_height=600, sizing_mode='scale_width'
+        width=800, height=600, sizing_mode='scale_width'
     )
     r = fig.multi_line(
         effirrad.tolist(), eff.tolist(), color=cmap, line_width=4)
@@ -146,7 +146,7 @@ def cec_module_detail(request, cec_module_id):
         x_axis_label='voltage, V [V]',
         y_axis_label='current, I [A]',
         title=cec_mod.Name,
-        plot_width=800, plot_height=600, sizing_mode='scale_width'
+        width=800, height=600, sizing_mode='scale_width'
     )
     plot = fig.multi_line(
         voltage.tolist(), current.tolist(), color=cmap, line_width=4)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bokeh==2.0.1
+bokeh==2.1.1
 defusedxml==0.7.1
 dj-database-url==2.2.0
 Django==4.2.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bokeh==2.2.2
+bokeh==2.3.3
 defusedxml==0.7.1
 dj-database-url==2.2.0
 Django==4.2.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bokeh==2.4.3
+bokeh==3.0.1
 defusedxml==0.7.1
 dj-database-url==2.2.0
 Django==4.2.20
@@ -6,18 +6,18 @@ django-tastypie==0.15.1
 gunicorn==23.0.0
 Jinja2==2.11.3
 lxml==4.9.1
-numpy==1.22.0
+numpy==1.26.4
 openpyxl==3.0.3
 pandas==1.3.5
 psycopg2==2.8.5
-pvlib==0.9.5
+pvlib==0.10.5
 pytest==8.3.5
 pytest-cov==6.1.0
 pytest-django==4.8.0
 pytz==2025.2
 python-dateutil==2.9.0
 PyYAML==5.4
-scipy==1.7.3
+scipy==1.13.1
 six==1.17.0
 whitenoise==6.3.0
 MarkupSafe==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bokeh==2.1.1
+bokeh==2.2.2
 defusedxml==0.7.1
 dj-database-url==2.2.0
 Django==4.2.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bokeh==2.3.3
+bokeh==2.4.3
 defusedxml==0.7.1
 dj-database-url==2.2.0
 Django==4.2.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ dj-database-url==2.2.0
 Django==4.2.20
 django-tastypie==0.15.1
 gunicorn==23.0.0
-Jinja2==2.11.3
+Jinja2==3.1.6
 lxml==4.9.1
 numpy==1.26.4
 openpyxl==3.0.3

--- a/templates/cec_module_detail.html
+++ b/templates/cec_module_detail.html
@@ -7,9 +7,9 @@
 <!--There are no more CSS files required. After Bokeh 1.3 there are no CSS includes that are necessary-->
 <!--https://discourse.bokeh.org/t/cdn-css-files-returns-empty-list-in-bokeh-1-3-4/3894/2-->
 
-<script src="https://cdn.bokeh.org/bokeh/release/bokeh-2.1.1.min.js"></script>
-<script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.1.1.min.js"></script>
-<script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.1.1.min.js"></script>
+<script src="https://cdn.bokeh.org/bokeh/release/bokeh-2.2.2.min.js"></script>
+<script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.2.2.min.js"></script>
+<script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.2.2.min.js"></script>
 
 {{ plot_script|safe }}
 

--- a/templates/cec_module_detail.html
+++ b/templates/cec_module_detail.html
@@ -7,21 +7,9 @@
 <!--There are no more CSS files required. After Bokeh 1.3 there are no CSS includes that are necessary-->
 <!--https://discourse.bokeh.org/t/cdn-css-files-returns-empty-list-in-bokeh-1-3-4/3894/2-->
 
-<!--
-<link
-    href="https://cdn.bokeh.org/bokeh/release/bokeh-2.0.1.min.css"
-    rel="stylesheet" type="text/css">
-<link
-    href="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.0.1.min.css"
-    rel="stylesheet" type="text/css">
-<link
-    href="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.0.1.min.css"
-    rel="stylesheet" type="text/css">
--->
-
-<script src="https://cdn.bokeh.org/bokeh/release/bokeh-2.0.1.min.js"></script>
-<script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.0.1.min.js"></script>
-<script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.0.1.min.js"></script>
+<script src="https://cdn.bokeh.org/bokeh/release/bokeh-2.1.1.min.js"></script>
+<script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.1.1.min.js"></script>
+<script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.1.1.min.js"></script>
 
 {{ plot_script|safe }}
 

--- a/templates/cec_module_detail.html
+++ b/templates/cec_module_detail.html
@@ -7,9 +7,9 @@
 <!--There are no more CSS files required. After Bokeh 1.3 there are no CSS includes that are necessary-->
 <!--https://discourse.bokeh.org/t/cdn-css-files-returns-empty-list-in-bokeh-1-3-4/3894/2-->
 
-<script src="https://cdn.bokeh.org/bokeh/release/bokeh-2.2.2.min.js"></script>
-<script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.2.2.min.js"></script>
-<script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.2.2.min.js"></script>
+<script src="https://cdn.bokeh.org/bokeh/release/bokeh-2.3.3.min.js"></script>
+<script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.3.3.min.js"></script>
+<script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.3.3.min.js"></script>
 
 {{ plot_script|safe }}
 

--- a/templates/cec_module_detail.html
+++ b/templates/cec_module_detail.html
@@ -7,9 +7,9 @@
 <!--There are no more CSS files required. After Bokeh 1.3 there are no CSS includes that are necessary-->
 <!--https://discourse.bokeh.org/t/cdn-css-files-returns-empty-list-in-bokeh-1-3-4/3894/2-->
 
-<script src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.3.min.js"></script>
-<script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.4.3.min.js"></script>
-<script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.4.3.min.js"></script>
+<script src="https://cdn.bokeh.org/bokeh/release/bokeh-3.0.1.min.js"></script>
+<script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-3.0.1.min.js"></script>
+<script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-3.0.1.min.js"></script>
 
 {{ plot_script|safe }}
 

--- a/templates/cec_module_detail.html
+++ b/templates/cec_module_detail.html
@@ -7,9 +7,9 @@
 <!--There are no more CSS files required. After Bokeh 1.3 there are no CSS includes that are necessary-->
 <!--https://discourse.bokeh.org/t/cdn-css-files-returns-empty-list-in-bokeh-1-3-4/3894/2-->
 
-<script src="https://cdn.bokeh.org/bokeh/release/bokeh-2.3.3.min.js"></script>
-<script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.3.3.min.js"></script>
-<script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.3.3.min.js"></script>
+<script src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.3.min.js"></script>
+<script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.4.3.min.js"></script>
+<script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.4.3.min.js"></script>
 
 {{ plot_script|safe }}
 

--- a/templates/pvinverter_detail.html
+++ b/templates/pvinverter_detail.html
@@ -7,9 +7,9 @@
 <!--There are no more CSS files required. After Bokeh 1.3 there are no CSS includes that are necessary-->
 <!--https://discourse.bokeh.org/t/cdn-css-files-returns-empty-list-in-bokeh-1-3-4/3894/2-->
 
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-2.1.1.min.js"></script>
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.1.1.min.js"></script>
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.1.1.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-2.2.2.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.2.2.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.2.2.min.js"></script>
 
 {{ plot_script|safe }}
 

--- a/templates/pvinverter_detail.html
+++ b/templates/pvinverter_detail.html
@@ -7,21 +7,9 @@
 <!--There are no more CSS files required. After Bokeh 1.3 there are no CSS includes that are necessary-->
 <!--https://discourse.bokeh.org/t/cdn-css-files-returns-empty-list-in-bokeh-1-3-4/3894/2-->
 
-<!--
-<link
-    href="https://cdn.bokeh.org/bokeh/release/bokeh-2.0.1.min.css"
-    rel="stylesheet" type="text/css">
-<link
-    href="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.0.1.min.css"
-    rel="stylesheet" type="text/css">
-<link
-    href="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.0.1.min.css"
-    rel="stylesheet" type="text/css">
--->
-
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-2.0.1.min.js"></script>
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.0.1.min.js"></script>
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.0.1.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-2.1.1.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.1.1.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.1.1.min.js"></script>
 
 {{ plot_script|safe }}
 

--- a/templates/pvinverter_detail.html
+++ b/templates/pvinverter_detail.html
@@ -7,9 +7,9 @@
 <!--There are no more CSS files required. After Bokeh 1.3 there are no CSS includes that are necessary-->
 <!--https://discourse.bokeh.org/t/cdn-css-files-returns-empty-list-in-bokeh-1-3-4/3894/2-->
 
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.3.min.js"></script>
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.4.3.min.js"></script>
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.4.3.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-3.0.1.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-3.0.1.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-3.0.1.min.js"></script>
 
 {{ plot_script|safe }}
 

--- a/templates/pvinverter_detail.html
+++ b/templates/pvinverter_detail.html
@@ -7,9 +7,9 @@
 <!--There are no more CSS files required. After Bokeh 1.3 there are no CSS includes that are necessary-->
 <!--https://discourse.bokeh.org/t/cdn-css-files-returns-empty-list-in-bokeh-1-3-4/3894/2-->
 
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-2.2.2.min.js"></script>
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.2.2.min.js"></script>
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.2.2.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-2.3.3.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.3.3.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.3.3.min.js"></script>
 
 {{ plot_script|safe }}
 

--- a/templates/pvinverter_detail.html
+++ b/templates/pvinverter_detail.html
@@ -7,9 +7,9 @@
 <!--There are no more CSS files required. After Bokeh 1.3 there are no CSS includes that are necessary-->
 <!--https://discourse.bokeh.org/t/cdn-css-files-returns-empty-list-in-bokeh-1-3-4/3894/2-->
 
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-2.3.3.min.js"></script>
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.3.3.min.js"></script>
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.3.3.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.3.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.4.3.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.4.3.min.js"></script>
 
 {{ plot_script|safe }}
 

--- a/templates/pvmodule_detail.html
+++ b/templates/pvmodule_detail.html
@@ -7,9 +7,9 @@
 <!--There are no more CSS files required. After Bokeh 1.3 there are no CSS includes that are necessary-->
 <!--https://discourse.bokeh.org/t/cdn-css-files-returns-empty-list-in-bokeh-1-3-4/3894/2-->
 
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-2.1.1.min.js"></script>
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.1.1.min.js"></script>
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.1.1.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-2.2.2.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.2.2.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.2.2.min.js"></script>
 
 {{ plot_script|safe }}
 

--- a/templates/pvmodule_detail.html
+++ b/templates/pvmodule_detail.html
@@ -7,21 +7,9 @@
 <!--There are no more CSS files required. After Bokeh 1.3 there are no CSS includes that are necessary-->
 <!--https://discourse.bokeh.org/t/cdn-css-files-returns-empty-list-in-bokeh-1-3-4/3894/2-->
 
-<!--
-<link
-    href="https://cdn.bokeh.org/bokeh/release/bokeh-2.0.1.min.css"
-    rel="stylesheet" type="text/css">
-<link
-    href="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.0.1.min.css"
-    rel="stylesheet" type="text/css">
-<link
-    href="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.0.1.min.css"
-    rel="stylesheet" type="text/css">
--->
-
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-2.0.1.min.js"></script>
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.0.1.min.js"></script>
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.0.1.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-2.1.1.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.1.1.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.1.1.min.js"></script>
 
 {{ plot_script|safe }}
 

--- a/templates/pvmodule_detail.html
+++ b/templates/pvmodule_detail.html
@@ -7,9 +7,9 @@
 <!--There are no more CSS files required. After Bokeh 1.3 there are no CSS includes that are necessary-->
 <!--https://discourse.bokeh.org/t/cdn-css-files-returns-empty-list-in-bokeh-1-3-4/3894/2-->
 
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.3.min.js"></script>
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.4.3.min.js"></script>
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.4.3.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-3.0.1.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-3.0.1.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-3.0.1.min.js"></script>
 
 {{ plot_script|safe }}
 

--- a/templates/pvmodule_detail.html
+++ b/templates/pvmodule_detail.html
@@ -7,9 +7,9 @@
 <!--There are no more CSS files required. After Bokeh 1.3 there are no CSS includes that are necessary-->
 <!--https://discourse.bokeh.org/t/cdn-css-files-returns-empty-list-in-bokeh-1-3-4/3894/2-->
 
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-2.2.2.min.js"></script>
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.2.2.min.js"></script>
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.2.2.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-2.3.3.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.3.3.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.3.3.min.js"></script>
 
 {{ plot_script|safe }}
 

--- a/templates/pvmodule_detail.html
+++ b/templates/pvmodule_detail.html
@@ -7,9 +7,9 @@
 <!--There are no more CSS files required. After Bokeh 1.3 there are no CSS includes that are necessary-->
 <!--https://discourse.bokeh.org/t/cdn-css-files-returns-empty-list-in-bokeh-1-3-4/3894/2-->
 
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-2.3.3.min.js"></script>
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.3.3.min.js"></script>
-    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.3.3.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.3.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.4.3.min.js"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.4.3.min.js"></script>
 
 {{ plot_script|safe }}
 


### PR DESCRIPTION
- update bokeh to v3.0.1
- pvlib to 0.10.5
- numpy to 1.26.4
- scipy to 1.13.1
- update bokeh cdn scripts to v3.0.1 in detail templates
- bokeh plot attributes changed to "width" `from plot_width` and to height from `plot_height`
- remove old commented code from html templates re: deprecated links for bokeh CSS