### PR TITLE
Serverside

### DIFF
--- a/parameters/api.py
+++ b/parameters/api.py
@@ -44,6 +44,11 @@ class PVModuleResource(ModelResource):
         authorization = IsAuthenticatedOrReadOnly()
         authentication = ApiKeyAuthOrReadOnly()
 
+    def dehydrate_Material(self, bundle):
+        celltype = bundle.data['Material']
+        # TODO: use dictionary instead of list
+        return PVModule.MATERIALS[celltype][1]
+
 
 class CECModuleResource(ModelResource):
     class Meta:

--- a/pvfree/views.py
+++ b/pvfree/views.py
@@ -136,6 +136,7 @@ def cec_modules(request):
             cecmod_set = CEC_Module.objects.all()
         filtered_records = cecmod_set.count()
         data = [{
+            'id': cecmod.id,
             'Name': cecmod.Name,
             'BIPV': cecmod.BIPV,
             'Date': cecmod.Date,

--- a/pvfree/views.py
+++ b/pvfree/views.py
@@ -107,19 +107,33 @@ def pvmodule_detail(request, pvmodule_id):
             'plot_div': plot_div, 'pvmod_dict': pvmod_dict})
 
 
+@csrf_exempt
 def cec_modules(request):
     if request.method == 'GET':
         # using datatables.net with ajax to return values from API
         return render(request, 'cec_modules.html', {'path': request.path})
     elif request.method == 'POST':
+        # to enable server-side processing change cec_modules.html
+        # datatables.net script:
+        # ajax: {
+        #   url: '{% url 'cec_modules' %}',
+        #   type: 'POST'
+        # },
+        # serverSide: true,
+        # processing: true,
         draw = int(request.POST.get('draw'))
         start = int(request.POST.get('start'))
         length = int(request.POST.get('length'))
         search_value = request.POST.get('search[value]')
         limit = start+length
         total_records = CEC_Module.objects.count()
+        # TODO: sort columns
         if search_value:
-            cecmod_set = CEC_Module.objects.filter(Name__icontains=search_value)
+            # TODO: search Technology choices
+            cecmod_set = (
+                CEC_Module.objects.filter(Name__icontains=search_value))
+        else:
+            cecmod_set = CEC_Module.objects.all()
         filtered_records = cecmod_set.count()
         data = [{
             'Name': cecmod.Name,

--- a/templates/cec_modules.html
+++ b/templates/cec_modules.html
@@ -11,7 +11,6 @@
 {% block content %}
 <div class="container">
   <h1 class="page-header">CEC Modules</h1>
-  {% if cec_mod_set %}
   <table id="myTable" class="table table-striped table-bordered">
     <thead>
       <tr>
@@ -47,9 +46,6 @@
       </tr>
     </tfoot>
   </table>
-  {% else %}
-     <p>No CEC Modules are available. Yet. Comming Soon!</p>
-  {% endif %}
 </div>
 {% endblock %}
 

--- a/templates/pvinverters.html
+++ b/templates/pvinverters.html
@@ -11,7 +11,6 @@
 {% block content %}
 <div class="container">
   <h1 class="page-header">PV Inverters</h1>
-  {% if pvinv_set %}
   <table id="myTable" class="table table-striped table-bordered">
     <thead>
       <tr>
@@ -34,29 +33,6 @@
         <th>CEC Type</th>
       </tr>
     </thead>
-    <!-- <tbody>
-      {% for pvinv in pvinv_set %}
-      <tr>
-        <td><a href="{% url 'pvinverter_detail' pvinv.id %}">{{ pvinv.Name }}</a></td>
-        <td>{{ pvinv.Vac }}</td>
-        <td>{{ pvinv.Paco }}</td>
-        <td>{{ pvinv.Vdco|floatformat }}</td>
-        <td>{{ pvinv.Pdco|floatformat }}</td>
-        <td>{{ pvinv.C0|stringformat:"5.2E" }}</td>
-        <td>{{ pvinv.C1|stringformat:"5.2E" }}</td>
-        <td>{{ pvinv.C2|stringformat:"5.2E" }}</td>
-        <td>{{ pvinv.C3|stringformat:"5.2E" }}</td>
-        <td>{{ pvinv.Pso|floatformat }}</td>
-        <td>{{ pvinv.Pnt }}</td>
-        <td>{{ pvinv.Vdcmax }}</td>
-        <td>{{ pvinv.Idcmax }}</td>
-        <td>{{ pvinv.Mppt_low }}</td>
-        <td>{{ pvinv.Mppt_high }}</td>
-        <td>{{ pvinv.CEC_Date }}</td>
-        <td>{{ pvinv.CEC_Type }}</td>
-      </tr>
-      {% endfor %}
-    </tbody> -->
     <!--<tbody>rendered by datatables.net</tbody>-->
     <tfoot>
       <tr>
@@ -80,9 +56,6 @@
       </tr>
     </tfoot>
   </table>
-  {% else %}
-     <p>No PV Inverters are available.</p>
-  {% endif %}
 </div>
 {% endblock %}
 
@@ -91,9 +64,6 @@
 <script src="https://cdn.datatables.net/2.2.2/js/dataTables.js"></script>
 <script src="https://cdn.datatables.net/2.2.2/js/dataTables.bootstrap.js"></script>
 <script>
-// <!-- $(document).ready(function(){
-//     $('#myTable').DataTable();
-// }); -->
 
 $(document).ready(function(){
   $('#myTable').DataTable({


### PR DESCRIPTION
enable serverside processing for CEC Modules

- if POST sent to page view then parse server args "draw", "start", "length" etc, and return query in datatables required format
- clean up comments from html
- don't need to retrieve pvinverters or cec modules if using datatables ajax to render, is this taking a lot of time?
- dehydrate sandia pvinverter material for api resource