### PR TITLE
Serverside pvinv

### DIFF
--- a/pvfree/api.py
+++ b/pvfree/api.py
@@ -198,7 +198,7 @@ def weather_resource(request):
             tmy_data, metadata = iotools.get_psm3(
                 latitude=tmy_lat, longitude=tmy_lon, api_key=tmy_nrel_key,
                 email=tmy_email, names=tmy_name, interval=tmy_freq,
-                leap_day='false', url=PSM4)
+                url=PSM4)
         except Exception as exc:
             # could be either HTTPError or ReadTimeout 
             return JsonResponse({'psm3': exc.args[0]}, status=400)

--- a/pvfree/forms.py
+++ b/pvfree/forms.py
@@ -89,7 +89,7 @@ class WeatherForm(forms.Form):
         2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020]
     YEAR_NAMES = list(zip(YEAR_NAMES, YEAR_NAMES))
     SRCS = [
-        ('pvgis', 'PVGIS'), ('psm3', 'PSM3'), ('tmy2', 'TMY2'),
+        ('pvgis', 'PVGIS'), ('psm4', 'PSM4'), ('tmy2', 'TMY2'),
         ('tmy3', 'TMY3')]
     FREQ = [5, 15, 30, 60]
     FREQ = list(zip(FREQ, FREQ))
@@ -108,7 +108,7 @@ class WeatherForm(forms.Form):
     tmy_freq = forms.ChoiceField(
         label='Frequency', required=False, initial=60, choices=FREQ)
     tmy_source = forms.ChoiceField(
-        label='Source', required=False, initial='psm3',
+        label='Source', required=False, initial='psm4',
         choices=SRCS)
     tmy = forms.BooleanField(label='TMY', required=False, initial=True)
     tmy_nrel_key = forms.CharField(

--- a/pvfree/forms.py
+++ b/pvfree/forms.py
@@ -89,8 +89,8 @@ class WeatherForm(forms.Form):
         2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020]
     YEAR_NAMES = list(zip(YEAR_NAMES, YEAR_NAMES))
     SRCS = [
-        ('pvgis', 'PVGIS'), ('psm4', 'PSM4'), ('tmy2', 'TMY2'),
-        ('tmy3', 'TMY3')]
+        ('pvgis', 'PVGIS'), ('psm3', 'PSM3'), ('psm4', 'PSM4'),
+        ('tmy2', 'TMY2'), ('tmy3', 'TMY3')]
     FREQ = [5, 15, 30, 60]
     FREQ = list(zip(FREQ, FREQ))
     #[(5, '5'), (15, '15'), (30, '30'), (60, '60')]

--- a/templates/base.html
+++ b/templates/base.html
@@ -183,6 +183,31 @@
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="https://maxcdn.bootstrapcdn.com/js/ie10-viewport-bug-workaround.js"></script>
 
+    <!-- Use js.cookie in lieu of Django script
+    <script src="https://cdn.jsdelivr.net/npm/js-cookie@3.0.5/dist/js.cookie.min.js"
+    integrity="sha256-WCzAhd2P6gRJF9Hv3oOOd+hFJi/QJbv+Azn4CGB8gfY=" crossorigin="anonymous"></script> -->
+    <!-- https://docs.djangoproject.com/en/5.2/howto/csrf/#using-csrf-protection-with-ajax -->
+    <script>
+    function getCookie(name) {
+      let cookieValue = null;
+      if (document.cookie && document.cookie !== '') {
+        const cookies = document.cookie.split(';');
+        for (let i = 0; i < cookies.length; i++) {
+          const cookie = cookies[i].trim();
+          // Does this cookie string begin with the name we want?
+          if (cookie.substring(0, name.length + 1) === (name + '=')) {
+            cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+            break;
+          }
+        }
+      }
+      return cookieValue;
+    }
+    const csrftoken = getCookie('csrftoken');
+    // const csrfmiddlewaretoken = document.querySelector('[name=csrfmiddlewaretoken]').value;
+    // const jscookie_csrftoken = Cookies.get('csrftoken');
+    </script>
+
     <script>
     // called only once when document is ready
     $(function(){

--- a/templates/cec_modules.html
+++ b/templates/cec_modules.html
@@ -57,8 +57,10 @@
 $(document).ready(function(){
   $('#myTable').DataTable({
     ajax: {
-      url: '{% url 'cec_modules' %}',
-      type: 'POST'
+      // mode: 'same-origin' // Do not send CSRF token to another domain.
+      url: "{% url 'cec_modules' %}",
+      type: 'POST',
+      headers: {'X-CSRFToken': csrftoken}
     },
     serverSide: true,
     processing: true,
@@ -66,7 +68,7 @@ $(document).ready(function(){
       {
         data: 'Name',
         render: function(data, type, row){
-          return '<a href="'+ {% url 'cec_modules' %} + row.id + '/">' + row.Name + '</a>'
+          return '<a href="' + "{% url 'cec_modules' %}" + row.id + '/">' + row.Name + '</a>'
         }
       },
       {data: 'Date'},

--- a/templates/pvinverters.html
+++ b/templates/pvinverters.html
@@ -59,15 +59,18 @@
 $(document).ready(function(){
   $('#myTable').DataTable({
     ajax: {
-      url: '/api/v1/pvinverter/?limit=0',
-      dataSrc: 'objects'
+      // mode: 'same-origin' // Do not send CSRF token to another domain.
+      url: "{% url 'pvinverters' %}",
+      type: 'POST',
+      headers: {'X-CSRFToken': csrftoken}
     },
-    deferRender: true,
+    serverSide: true,
+    processing: true,
     columns: [
       {
         data: 'Name',
         render: function(data, type, row){
-          return '<a href="'+ {% url 'pvinverters' %} + row.id + '/">' + row.Name + '</a>'
+          return '<a href="' + "{% url 'pvinverters' %}" + row.id + '/">' + row.Name + '</a>'
         }
       },
       {data: 'Vac'},

--- a/templates/pvlib.html
+++ b/templates/pvlib.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block headers %}
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/default.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/default.min.css">
 <!-- <link rel="stylesheet" href="{% static 'highlight/styles/default.css' %}"> -->
 <script src="https://cdn.jsdelivr.net/npm/vega@5.22.1"></script>
 <script src="https://cdn.jsdelivr.net/npm/vega-lite@5.6.1"></script>
@@ -402,7 +402,7 @@ crossorigin=""></script>
 {% endblock %}
 
 {% block footers %}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js"></script>
 <!-- <script src="{% static 'highlight/highlight.pack.js' %}"></script> -->
 <script>hljs.initHighlightingOnLoad();</script>
 <script>
@@ -636,7 +636,6 @@ crossorigin=""></script>
       $.each($("#am_form").serializeArray(), function(){
         params[this.name] = this.value;
       });
-      //params['zenith_data'] = JSON.parse(params['zenith_data']);
       console.log(params);
       var am_url = "/api/v1/pvlib/airmass/";
       $("#airmass").empty();
@@ -645,21 +644,28 @@ crossorigin=""></script>
       };
       $("#am_code").empty();
       $("<pre>", {html: 'curl -H "Content-Type: application/json" -X POST ' + am_url + " -d '" + JSON.stringify(params) + "'"}).appendTo("#am_code");
-      $.post( am_url, params, function( data ) {
-        console.log(data);
-        $.each( data, function( date, record ) {
-          row = "<tr><td><b>" + date + "</b></td><td>" + record + "</td></tr>"
-          items.push( row );
-        });
-        items = "<tbody>" + items.join( "" ) + "</tbody>";
-        headers = "<th>" + headers.join("</th><th>") + "</th>";
-        $("#airmass").css({"height": "500px", "overflow": "auto"});
-        $( "<table>", {
-          "id": "airmassTable",
-          "class": "table table-striped table-bordered table-condensed",
-          html: "<thead>" + headers + "</thead>" + items
-        }).appendTo( "#airmass" );
-      }, "json").fail(function(err){
+      $.post({
+        // mode: 'same-origin', // Do not send CSRF token to another domain.
+        url: am_url,
+        headers: {'X-CSRFToken': csrftoken},
+        data: params,
+        dataType: "json",
+        success: function( data ) {
+          console.log(data);
+          $.each( data, function( date, record ) {
+            row = "<tr><td><b>" + date + "</b></td><td>" + record + "</td></tr>"
+            items.push( row );
+          });
+          items = "<tbody>" + items.join( "" ) + "</tbody>";
+          headers = "<th>" + headers.join("</th><th>") + "</th>";
+          $("#airmass").css({"height": "500px", "overflow": "auto"});
+          $( "<table>", {
+            "id": "airmassTable",
+            "class": "table table-striped table-bordered table-condensed",
+            html: "<thead>" + headers + "</thead>" + items
+          }).appendTo( "#airmass" );
+        }
+      }).fail(function(err){
         $("#am_code").html('<pre class="alert alert-danger" role="alert">' + err.responseText + "</pre>");
       });
     });

--- a/templates/pvmodules.html
+++ b/templates/pvmodules.html
@@ -57,11 +57,6 @@
 <!-- datatables.net -->
 <script src="https://cdn.datatables.net/2.2.2/js/dataTables.js"></script>
 <script src="https://cdn.datatables.net/2.2.2/js/dataTables.bootstrap.js"></script>
-<!--script>
-$(document).ready(function(){
-    $('#myTable').DataTable();
-});
-</script-->
 <script>
   $(document).ready(function(){
     $('#myTable').DataTable({
@@ -74,7 +69,7 @@ $(document).ready(function(){
         {
           data: 'Name',
           render: function(data, type, row){
-            return '<a href="'+ {% url 'pvmodules' %} + row.id + '/">' + row.Name + '</a>'
+            return '<a href="' + "{% url 'pvmodules' %}" + row.id + '/">' + row.Name + '</a>'
           }
         },
         {data: 'Vintage'},


### PR DESCRIPTION
closes #67 

- use server-side processing on POST for pv inverters instead of ajax/deferred-render from API, which is too slow
- add Django script to base template to get csrf token from cookie, and pass it to ajax calls in header, instead decorating views with Django `csrf_exempt`
- update highlight.js form v9 to v11 (latest) in pvlib page
- use csrf token from cookie when posting airmass request instead of Django csrf_exempt decorator
- add url to psm4 and pass url argument to `pvlib.iotools.get_psm3(..., url=PSM4)` in weather resource view
- add quotes around urls extract from Django tags in templates, browser is too forgiving
- add comment to call ajax in same-origin mode, this is not a jQuery argument, but the url is in the code, so comment is there to remind reader